### PR TITLE
Add process.env variable for license key

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -15,7 +15,7 @@ exports.config = {
   /**
    * Your New Relic license key.
    */
-  license_key: NEWRELIC.LICENSE_KEY,
+  license_key: process.env.NEW_RELIC_LICENSE_KEY || NEWRELIC.LICENSE_KEY,
   logging: {
     /**
      * Level at which to log. 'trace' is most useful to New Relic when diagnosing


### PR DESCRIPTION
Added a process.env variable to be able to run New Relic (specifically, the license key) on the EC2 instance